### PR TITLE
Add -p flag for mkdir command

### DIFF
--- a/attest.sh
+++ b/attest.sh
@@ -49,7 +49,7 @@ verify_archive() {
 tfenv_install() {
     tfenv_ver=$(tfenv -v | awk '{print $2}')
     tfenv_version_path=/usr/local/Cellar/tfenv/"$tfenv_ver"/versions/"$tversion"
-    [ ! -d "$tfenv_version_path" ] && mkdir "$tfenv_version_path"
+    [ ! -d "$tfenv_version_path" ] && mkdir -p "$tfenv_version_path"
     set -vx
     tar xvfz $terraform -C $tfenv_version_path
 }


### PR DESCRIPTION
Found a bug whereby after I upgraded tfenv to a newer version, the script was unable to create the directory